### PR TITLE
Fix RTTL typos to RTTTL

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Dive into the world of smart home technology by integrating your AWTRIX3 Smart P
 - **Power Control:** Toggle the power state of the AWTRIX3 display.
 - **Temperature, Humidity, and Illumination:** Fetch and display temperature, humidity, and illumination stats.
 - **Push Button Notifications:** Use virtual devices to trigger notifications or custom applications based on button input.
-- **Send RTTL Sounds:** Use virtual devices to play RTTTL sounds on the device.
+- **Send RTTTL Sounds:** Use virtual devices to play RTTTL sounds on the device.
 - **Debugging Options:** Multiple levels of debugging to help you get precise information about the plugin activities.
 
 ## 🛠 Installation
@@ -44,7 +44,7 @@ Dive into the world of smart home technology by integrating your AWTRIX3 Smart P
 - **Send Custom App:** Virtual device to send custom applications data via the AWTRIX3 API.
 - **Next App:** Navigate to the next app via the AWTRIX3 API.
 - **Previous App:** Navigate to the previous app via the AWTRIX3 API.
-- **RTTTL:** Start a RTTL Melodie on the device.
+- **RTTTL:** Start a RTTTL Melodie on the device.
 
 ## 🚀 Usage
 ### Push Button Notifications


### PR DESCRIPTION
The README.md contains 'RTTL' where it should be 'RTTTL'. 
Fixed those typing errors. 