### PR TITLE
Fixes the link to the AWTRIX3 API in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ For more details on AWTRIX3 and how to upload/setup icons:
 [AWTRIX Icons Setup](https://blueforcer.github.io/awtrix3/#/icons)
 
 ### Settings
-The description of the push button (`Send settings`) should be set to a JSON object, using the keys and values as defined by the [AWTRIX3 API](https://blueforcer.github.io/awtrix3/#change-settings).
+The description of the push button (`Send settings`) should be set to a JSON object, using the keys and values as defined by the [AWTRIX3 API](https://blueforcer.github.io/awtrix3/#/api?id=change-settings).
 
 #### Example JSONs for changing the global settings
 | Example                                       | JSON                                              |


### PR DESCRIPTION
The link on the MQTT/HTTP page of AWTRIX3, uses an unexpected tag-names. The new link is working correctly to jump to the corresponding section.