### PR TITLE
Allow to specify an 'appname' in the JSON data for the custom app

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Dive into the world of smart home technology by integrating your AWTRIX3 Smart P
 The description of the push buttons (`Send Notification` and `Send Custom App`) can be used in three ways:
 1. **JSON:**
    - Example: `{ "text": "600 L", "icon": 9766 }`
+   - Multi page example `[{ "text": "600 L", "icon": 9766 }, { "text": "364 W", "icon": 95 }]`
 2. **Icon;Message:**
    - Format: `icon;message`
    - Example: `9766;Check the temperature!`
@@ -80,6 +81,10 @@ If you like to use dzVents to set the description of the notification and custom
 For more details on all JSON options:
 [Custom Apps and Notifications](https://blueforcer.github.io/awtrix3/#/api?id=custom-apps-and-notifications)
 
+If multiple dzVents scripts are used to send different 'Custom Apps' to the AWTRIX3
+using the 'Send Custom App' button, it is best to also include an "appname" key and an appropriate
+value in the JSON data, as otherwise the 'Custom Apps' of the other dzVents scripts will be overwritten.
+ 
 ### Icons
 To display icons on the AWTRIX3 device, you need to manually upload them. You can fetch icons from the [LaMetric Developer Site](https://developer.lametric.com/icons).
 

--- a/plugin.py
+++ b/plugin.py
@@ -35,6 +35,7 @@ import Domoticz
 import requests
 from requests.auth import HTTPBasicAuth
 import json
+import json.decoder
 
 class BasePlugin:
     def __init__(self):
@@ -415,10 +416,24 @@ class BasePlugin:
         except requests.exceptions.RequestException as e:
             Domoticz.Error(f"Failed to send Notify message: {e}")
 
+    def _determine_custom_app_name(self, json_data):
+        appname = self.custom_app_name
+        try:
+            jd = json.loads(json_data)
+            json_list = jd if isinstance(jd, list) else [jd]
+            for app in json_list:
+                appname = app.get("appname", "")
+                if appname:
+                    return appname
+        except json.decoder.JSONDecodeError as e:
+            Domoticz.Error(f"Invalid JSON data passed: {json_data}")
+
+        return self.custom_app_name
+
     def send_custom_app_json(self, json_data):
         url = f"http://{self.awtrix_ip}/api/custom"
         headers = {"Content-Type": "application/json"}
-        p = {"name": self.custom_app_name}
+        p = {"name": self._determine_custom_app_name(json_data) }
         try:
             response = requests.post(url, data=json_data, params=p, headers=headers, auth=(self.username, self.password))
             response.raise_for_status()

--- a/plugin.py
+++ b/plugin.py
@@ -36,6 +36,7 @@ import requests
 from requests.auth import HTTPBasicAuth
 import json
 import json.decoder
+import re
 
 class BasePlugin:
     def __init__(self):
@@ -423,8 +424,12 @@ class BasePlugin:
             json_list = jd if isinstance(jd, list) else [jd]
             for app in json_list:
                 appname = app.get("appname", "")
-                if appname:
-                    return appname
+                # Only keep valid characters as it will be passed on an URL
+                sanitized_appname = re.sub(r'[^a-zA-Z0-9_]', '', appname)
+                if sanitized_appname:
+                    if sanitized_appname != appname:
+                        Domoticz.Error(f"appname: '{appname}' was sanitized to: '{sanitized_appname}'")
+                    return sanitized_appname
         except json.decoder.JSONDecodeError as e:
             Domoticz.Error(f"Invalid JSON data passed: {json_data}")
 


### PR DESCRIPTION
To allow multiple dzVents scripts can update the custom app pages on the AWTRIX3, it should be possible that each upload of the custom app JSON, is using a different appname. 
It otherwise overwrites the custom app pages of another script, as 'Domoticz' is used for every custom app page.

By including the 'appname' key in the JSON data, the first determined 'appname' will be used to upload the custom pages. 

One dzVents script can thus inject: `[{"appname": "temp", "text": "14.5 C", "icon": 2355}]` while another script can use: `[{"appname": "down_upload", "text": "D: 14.5 GB", "icon": 60903}, {"text": "U: 4.5 GB", "icon": 60903}]`.

If no 'appname' key is present in the JSON data, the previously used 'Domoticz' appname will still be used.

The big benefit is that with this change, multiple dzVents script can be used instead of being limited to a single dzVents scripts that updates all the custom app pages.
