### PR TITLE
Remove the power status check of the AWTRIX in the sample scripts

### DIFF
--- a/samples/dzvents-next-app-sample.txt
+++ b/samples/dzvents-next-app-sample.txt
@@ -17,11 +17,6 @@ return {
 
     -- Event execution when the timer triggers the script
     execute = function(domoticz)
-        local powerDevice = domoticz.devices("AWTRIX3 - Power")
-        if not powerDevice or powerDevice.state ~= "On" then
-            return
-        end
-
         local appNextDevice = domoticz.devices('AWTRIX3 - Next App')
         appNextDevice.switchOn()
     end

--- a/samples/dzvents-sample.txt
+++ b/samples/dzvents-sample.txt
@@ -48,15 +48,6 @@ return {
             ["Gas"] = { icon = 54633, type = "gas" }
         }
         
-        -- Check if the "AWTRIX3 - Power" device is on
-        local powerDevice = domoticz.devices("AWTRIX3 - Power")
-        if not powerDevice or powerDevice.state ~= "On" then
-            domoticz.log("AWTRIX3 - Power device is off. Skipping status updates.", domoticz.LOG_INFO)
-            return
-        else
-            domoticz.log("AWTRIX3 - Power device is on. Proceeding with status updates.", domoticz.LOG_INFO)
-        end
-
         local statuses = {}
 
         -- Function to generate JSON description ({"text": "status", "icon": icon})

--- a/samples/dzvents-weather-overlay-sample.txt
+++ b/samples/dzvents-weather-overlay-sample.txt
@@ -15,11 +15,6 @@ return {
     },
 
     execute = function(domoticz)
-        local powerDevice = domoticz.devices("AWTRIX3 - Power")
-        if not powerDevice or powerDevice.state ~= "On" then
-            return
-        end
-        
         -- Fetch the weather device
         local weatherDevice = domoticz.devices("Buiten temperatuur") -- 'Your outside weather device'
         if not weatherDevice then


### PR DESCRIPTION
Remove the check if the power of the AWTRIX is on in the provided sample scripts. Because this could trigger a situation that the state of the shown information is not correct when the power is activated again.

Also, the web-based LiveView of the AWTRIX will continue to show information, even if the power of the AWTRIX is turned off. To have up to date information on the web-based LiveView it thus is necessary to still send status information, even when the power of the AWTRIX is off. 

Another reason to remove the check is that if the 'AWTRIX3 - Power' device is not set as a 'Used device' in Domoticz, it will not be detected by dzVents, and thus no updates will be send.

Small side note: The 'Power' state of the AWTRIX is more a 'Physical display on/off' state, as all the other functionality of the AWTRIX will continue to work.